### PR TITLE
Fix #101: Added missing docblocks for the MarkAsFinalizedAction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added missing docblocks in the `MarkAsFinalizedAction.php` file. (#101)
 - Added docblocks for the Incident Impact Enumeration (#102)
 - Added `$filter` docblock in the the UtilityUsageWidget (#100)
 - Added support for PHPStan 2.0 at level 7.

--- a/app/Filament/Resources/QuotationResource/Actions/MarkAsFinalizedAction.php
+++ b/app/Filament/Resources/QuotationResource/Actions/MarkAsFinalizedAction.php
@@ -18,6 +18,8 @@ use Saade\FilamentAutograph\Forms\Components\SignaturePad;
  * This final class defines the action for marking an invoice as finalized within the Filament admin panel.
  * It configures the action button with a specific color, icon, visibility condition, and a confirmation requirement.
  * Upon execution, it updates the invoice status and sends a success notification.
+ *
+ * @package App\Filament\Resources\QuotationResource\Actions
  */
 final class MarkAsFinalizedAction extends Action
 {
@@ -44,8 +46,10 @@ final class MarkAsFinalizedAction extends Action
     }
 
     /**
+     * Defines the form schema shown in the confirmation modal.
+     * The user must sign the quotation before finalizing it.
      *
-     * @return array<\Filament\Forms\Components\Component>
+     * @return array<\Filament\Forms\Components\Component>  An array of form components for the modal.
      */
     private static function modalFormConfiguration(): array
     {
@@ -58,8 +62,14 @@ final class MarkAsFinalizedAction extends Action
     }
 
     /**
-     * @param  array<mixed>  $formData
-     * @param  Quotation     $quotation
+     * Handles the action when the user confirms finalization.
+     *
+     * - Saves the signature and timestamp.
+     * - Updates the quotation status.
+     * - Sends a notification confirming the change.
+     *
+     * @param  array<mixed>  $formData   Data from the form (contains the signature)
+     * @param  Quotation     $quotation  The quotation being finalized.
      * @return void
      */
     private static function performActionLogic(array $formData, Quotation $quotation): void


### PR DESCRIPTION
## Beschrijving

Deze pull request voegt de missende docblocks to voor de `MarkAsFinalizedAction.php` file. 

## Type van de pull request

- [x] Probleem oplossing (een niet afbrekende wijziging die een probleem verhelpt)
- [ ] Nieuwe functionaliteit (niet afbrekende wijziging die eren nieuwe functionaliteit toevoegd)
- [x] Refactoring van bestaande code (het verbeteren/herschrijven van bestaa,de project code)
- [ ] Brekende wijziging (Deze wijziging vereist een wijziging in de documentatie van het prooject)
- [x] Andere

# Fixed #101 

## Hoe is deze pull request getest? 

### Checklist 

- [x] Mijn code volgt de styleguide van dit project. 
- [x] Ik heb een zelfbeoordeling van mijn eigen code uitgevoerd. 
- [x] Ik heb mijn code becommentarieerd, vooral op moeilijk begrijpbare gebieden. 
- [x] Ik heb overeenkomstige wijzigingen aangebracht in de documentatie. 
- [x] Mijn wijzigingen genereren geen nieuwe waarschuwingen 
- [x] Ik heb tests toegevoegd die bewijzen dat mijn oplossing effectief aantonen dat mijn functionalityeit of fix werkt. 
- [x] Nieuwe en bestaande unit-tests slag in mijn lokale opmgeving met mijn wijzigingen. 
